### PR TITLE
github: Add QA job

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -1,0 +1,31 @@
+name: QA
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10' 
+      - name: apt
+        run: |
+          sudo apt update -y
+          DEBIAN_FRONTEND=noninteractive sudo apt install -y \
+            python3-pytest flake8
+      - name: flake8 misc
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 misc --exit-zero --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 misc --exit-zero --count --max-complexity=10 --max-line-length=127 --statistics
+      - run: pytest-3 -vvv misc
+


### PR DESCRIPTION
Add basic QA job for github actions.

The flake8 job would use `--zero-exit` for now. It should be removed once the issues are fixed.

Also to be extended once more code is coming.