### PR TITLE
ci: Extend QA pass

### DIFF
--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -20,7 +20,17 @@ jobs:
         run: |
           sudo apt update -y
           DEBIAN_FRONTEND=noninteractive sudo apt install -y \
-            python3-pytest flake8
+            python3-pip python3-pytest flake8
+      - name: pip
+        run: |
+          pip3 install qmp
+      - name: flake8 test
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 test --exit-zero --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 test --exit-zero --count --max-complexity=10 --max-line-length=127 --statistics
+      - run: pytest-3 -vvv test
       - name: flake8 misc
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/.github/workflows/qa.yaml
+++ b/.github/workflows/qa.yaml
@@ -24,12 +24,18 @@ jobs:
       - name: pip
         run: |
           pip3 install qmp
+      - name: flake8 src
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 src --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 src --count --max-complexity=10 --max-line-length=127 --statistics
       - name: flake8 test
         run: |
           # stop the build if there are Python syntax errors or undefined names
-          flake8 test --exit-zero --count --select=E9,F63,F7,F82 --show-source --statistics
+          flake8 test --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 test --exit-zero --count --max-complexity=10 --max-line-length=127 --statistics
+          flake8 test --count --max-complexity=10 --max-line-length=127 --statistics
       - run: pytest-3 -vvv test
       - name: flake8 misc
         run: |


### PR DESCRIPTION
Commence running tests from the `test` folder and add flake8 run over `src` and `test`.

Signed-off-by: Anatol Belski <anbelski@linux.microsoft.com>