### PR TITLE
integration: Enable DHCP in guest image by default

### DIFF
--- a/asset/00-ens.network
+++ b/asset/00-ens.network
@@ -1,0 +1,6 @@
+[Match]
+Name=en*
+
+[Network]
+DHCP=ipv4
+

--- a/scripts/make_guest_img
+++ b/scripts/make_guest_img
@@ -24,6 +24,7 @@ sudo mount -o offset=$[${OFFSET}*${SECTOR_SIZE}] "${IMG_PATH_RAW}" "${MOUNT_POIN
 
 sudo cp -a "${REPO_ROOT}" "${MOUNT_POINT}/ga-repo"
 sudo cp "${REPO_ROOT}/asset/cloud-hypervisor-ga.service" "${MOUNT_POINT}/lib/systemd/system/"
+sudo cp "${REPO_ROOT}/asset/00-ens.network" "${MOUNT_POINT}/etc/systemd/network/"
 sudo mv "${MOUNT_POINT}/etc/resolv.conf" "${MOUNT_POINT}/etc/resolv.conf.bak" || true
 echo "nameserver 8.8.8.8" | sudo tee "${MOUNT_POINT}/etc/resolv.conf"
 


### PR DESCRIPTION
While on host, dnsmasq can be used to autoconfigure the guest network. However, this requires the guest to be able to pick up the configuration. The guest agent would usually be responsible for configuring the network within the guest. A solution might be also to put a pre-set systemd config, however this should be seen as a temporary measure.